### PR TITLE
fix: parse VS Code .jsonl chat sessions

### DIFF
--- a/src/ai_log_viewer/vscode_parser.py
+++ b/src/ai_log_viewer/vscode_parser.py
@@ -95,48 +95,54 @@ def _read_session_json(path: Path) -> dict | None:
     try:
         if path.suffix == ".jsonl":
             with open(path) as f:
-                state = {}
+                state: dict = {}
                 for line in f:
                     line = line.strip()
                     if not line:
                         continue
-                    wrapper = json.loads(line)
+                    try:
+                        wrapper = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
                     if not isinstance(wrapper, dict):
                         continue
                     kind = wrapper.get("kind")
-                    if kind == 0:
-                        state = wrapper.get("v", {})
-                    elif kind in (1, 2):
-                        keys = wrapper.get("k", [])
-                        value = wrapper.get("v")
-                        if len(keys) == 1:
-                            state[keys[0]] = value
-                        elif len(keys) == 2:
-                            k0, k1 = keys[0], keys[1]
-                            if isinstance(k1, int):
+                    try:
+                        if kind == 0:
+                            state = wrapper.get("v", {})
+                        elif kind in (1, 2):
+                            keys = wrapper.get("k", [])
+                            value = wrapper.get("v")
+                            if len(keys) == 1:
+                                state[keys[0]] = value
+                            elif len(keys) == 2:
+                                k0, k1 = keys[0], keys[1]
+                                if isinstance(k1, int):
+                                    if not isinstance(state.get(k0), list):
+                                        state[k0] = []
+                                    while len(state[k0]) <= k1:
+                                        state[k0].append({})
+                                    state[k0][k1] = value
+                                else:
+                                    if not isinstance(state.get(k0), dict):
+                                        state[k0] = {}
+                                    state[k0][k1] = value
+                            elif len(keys) == 3:
+                                k0, k1, k2 = keys[0], keys[1], keys[2]
                                 if not isinstance(state.get(k0), list):
                                     state[k0] = []
                                 while len(state[k0]) <= k1:
                                     state[k0].append({})
-                                state[k0][k1] = value
-                            else:
-                                if not isinstance(state.get(k0), dict):
-                                    state[k0] = {}
-                                state[k0][k1] = value
-                        elif len(keys) == 3:
-                            k0, k1, k2 = keys[0], keys[1], keys[2]
-                            if not isinstance(state.get(k0), list):
-                                state[k0] = []
-                            while len(state[k0]) <= k1:
-                                state[k0].append({})
-                            if not isinstance(state[k0][k1], dict):
-                                state[k0][k1] = {}
-                            state[k0][k1][k2] = value
+                                if not isinstance(state[k0][k1], dict):
+                                    state[k0][k1] = {}
+                                state[k0][k1][k2] = value
+                    except (TypeError, IndexError, AttributeError, KeyError):
+                        continue
                 return state if state else None
         else:
             with open(path) as f:
                 return json.load(f)
-    except (json.JSONDecodeError, OSError, TypeError, IndexError, AttributeError):
+    except (json.JSONDecodeError, OSError):
         return None
 
 

--- a/tests/test_vscode_parser.py
+++ b/tests/test_vscode_parser.py
@@ -208,6 +208,89 @@ def test_discover_empty_dir(tmp_path: Path) -> None:
     assert sessions == []
 
 
+def test_jsonl_patch_reconstruction(tmp_path: Path) -> None:
+    """JSONL kind 1/2 patches reconstruct the full session state."""
+    ws_dir = tmp_path / "workspaceStorage" / "patchhash"
+    chat_dir = ws_dir / "chatSessions"
+    chat_dir.mkdir(parents=True)
+    (ws_dir / "workspace.json").write_text(
+        json.dumps({"folder": "file:///tmp/proj"})
+    )
+
+    # kind 0: initial snapshot with one request
+    session = _make_session(
+        session_id="cccccccc-dddd-eeee-ffff-000000000000",
+        custom_title="Initial title",
+    )
+    lines = [json.dumps({"kind": 0, "v": session})]
+    # kind 1: update top-level key (customTitle)
+    lines.append(json.dumps({"kind": 1, "k": ["customTitle"], "v": "Patched title"}))
+    # kind 2: update nested key (requests[0].isCanceled)
+    lines.append(json.dumps({"kind": 2, "k": ["requests", 0, "isCanceled"], "v": True}))
+
+    jsonl_path = chat_dir / "cccccccc-dddd-eeee-ffff-000000000000.jsonl"
+    jsonl_path.write_text("\n".join(lines) + "\n")
+
+    sessions = discover_sessions(tmp_path)
+    assert len(sessions) == 1
+    assert sessions[0]["summary"] == "Patched title"
+
+    events = parse_events(jsonl_path)
+    assert len(events) >= 2  # meta + request(s)
+    assert events[0]["sessionId"] == "cccccccc-dddd-eeee-ffff-000000000000"
+
+
+def test_jsonl_patch_two_level_dict_key(tmp_path: Path) -> None:
+    """JSONL kind 1 with a 2-level dict key path works."""
+    ws_dir = tmp_path / "workspaceStorage" / "dicthash"
+    chat_dir = ws_dir / "chatSessions"
+    chat_dir.mkdir(parents=True)
+    (ws_dir / "workspace.json").write_text(
+        json.dumps({"folder": "file:///tmp/proj"})
+    )
+
+    session = _make_session(
+        session_id="dddddddd-eeee-ffff-0000-111111111111",
+    )
+    lines = [
+        json.dumps({"kind": 0, "v": session}),
+        # Add hasPendingEdits via a 1-key patch
+        json.dumps({"kind": 1, "k": ["hasPendingEdits"], "v": True}),
+    ]
+    jsonl_path = chat_dir / "dddddddd-eeee-ffff-0000-111111111111.jsonl"
+    jsonl_path.write_text("\n".join(lines) + "\n")
+
+    sessions = discover_sessions(tmp_path)
+    assert len(sessions) == 1
+    assert sessions[0].get("has_pending_edits") is True
+
+
+def test_jsonl_malformed_patch_ignored(tmp_path: Path) -> None:
+    """Malformed JSONL patches don't crash the parser."""
+    ws_dir = tmp_path / "workspaceStorage" / "badhash"
+    chat_dir = ws_dir / "chatSessions"
+    chat_dir.mkdir(parents=True)
+    (ws_dir / "workspace.json").write_text(
+        json.dumps({"folder": "file:///tmp/proj"})
+    )
+
+    session = _make_session(
+        session_id="eeeeeeee-ffff-0000-1111-222222222222",
+    )
+    lines = [
+        json.dumps({"kind": 0, "v": session}),
+        "not valid json",
+        json.dumps({"kind": 1, "k": [], "v": "empty keys"}),
+        json.dumps({"kind": 99, "k": ["x"], "v": "unknown kind"}),
+    ]
+    jsonl_path = chat_dir / "eeeeeeee-ffff-0000-1111-222222222222.jsonl"
+    jsonl_path.write_text("\n".join(lines) + "\n")
+
+    # Should not crash, should still discover the session
+    sessions = discover_sessions(tmp_path)
+    assert len(sessions) == 1
+
+
 # ---------------------------------------------------------------------------
 # parse_events
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Recent versions of VS Code save chat sessions as `.jsonl` files inside `workspaceStorage/{hash}/chatSessions/`. 
These sessions were not showing up in the viewer for two reasons:

- `discover_sessions` only searched for `*.json` files, so `.jsonl`  files were never found.

- `_read_session_json` only read the first line of `.jsonl` files and returned immediately. The first line always contains an empty session (no messages), so these sessions were discarded.

## Root cause

As VS Code's `.jsonl` format is a log of patch operations, not a full snapshot, each line is an instruction:

- `kind 0` — initial state (empty session)
- `kind 1` / `kind 2` — patch operations that update specific fields

The final state of the session can only be reconstructed by reading all lines and applying each patch in order.

## Fix

- `discover_sessions`: added `*.jsonl` to the glob pattern for  `chatSessions/`

- `_read_session_json`: rewrote the `.jsonl` branch to iterate over all lines and apply patches to a `state` dict, supporting keys of depth 1, 2 and 3

## Tested on

Linux, VS Code 1.110.1, with real session files using the `kind 0/1/2` patch format.