### PR TITLE
ci: fix pip-audit — drop stale CVE-2026-3219 ignore, add PYSEC-2026-89

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -49,11 +49,9 @@ jobs:
           pip install -r .github/requirements-security.txt
           pip install -e .
       - name: Audit dependencies
-        # CVE-2026-3219 is a vuln in pip itself (the runner's bundled pip,
-        # not a project dep). No fixed pip release is out yet; ignore the
-        # specific CVE so unrelated PRs don't get blocked, and remove this
-        # ignore once upstream pip publishes the fix.
-        run: pip-audit --ignore-vuln CVE-2026-3219
+        # PYSEC-2026-89: DoS in python-markdown 3.10.2 (latest); no fix release
+        # yet. Remove once upstream publishes a patched version.
+        run: pip-audit --ignore-vuln PYSEC-2026-89
 
   zizmor:
     name: zizmor (GitHub Actions security)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -772,7 +772,9 @@ def test_search_skips_fallback_when_cache_ready(tmp_path: Path) -> None:
     # Patch out the background build so it can't race with our manual status
     # manipulation below — build_cache resets status to "building" on entry.
     with patch("ai_ctrl_plane.app.start_background_build"), patch("ai_ctrl_plane.app.start_background_refresh"):
-        app = create_app(tmp_path / "copilot", tmp_path / "claude_logs", tmp_path / "vscode", cache_dir=tmp_path / "cache")
+        app = create_app(
+            tmp_path / "copilot", tmp_path / "claude_logs", tmp_path / "vscode", cache_dir=tmp_path / "cache"
+        )
     app.config["TESTING"] = True
 
     db = app.config["cache_db"]

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import textwrap
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -768,7 +769,10 @@ def test_search_skips_fallback_when_cache_ready(tmp_path: Path) -> None:
             + "\n"
         )
 
-    app = create_app(tmp_path / "copilot", tmp_path / "claude_logs", tmp_path / "vscode", cache_dir=tmp_path / "cache")
+    # Patch out the background build so it can't race with our manual status
+    # manipulation below — build_cache resets status to "building" on entry.
+    with patch("ai_ctrl_plane.app.start_background_build"), patch("ai_ctrl_plane.app.start_background_refresh"):
+        app = create_app(tmp_path / "copilot", tmp_path / "claude_logs", tmp_path / "vscode", cache_dir=tmp_path / "cache")
     app.config["TESTING"] = True
 
     db = app.config["cache_db"]


### PR DESCRIPTION
Fixes the failing `pip-audit` job in the Security workflow.

The runner's pip is upgraded to 26.1+ in the install step, which fixes CVE-2026-3219 natively — the `--ignore-vuln` workaround is no longer needed. Replaces it with an ignore for PYSEC-2026-89 (DoS in python-markdown 3.10.2), which has no upstream fix yet. Remove that ignore once a patched release of python-markdown ships.