### PR TITLE
ci: fix OpenSSF Scorecard publish failure

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -101,13 +101,10 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - name: Configure credentials
-        uses: tracebit-com/tracebit-community-action@3a99261dae897b6a73b2d04d88cfc832a8f18f4b
-        with:
-          api-token: ${{ secrets.SECURITY_API_TOKEN }}
-          profile: admin
-          profile-region: us-east-1
-          async: true
+      # NOTE: Do not add extra steps (e.g. the Tracebit canary step used in the
+      # other jobs) to this job. When publish_results is true, the Scorecard
+      # webapp verifies this job contains only an allowlisted set of steps and
+      # rejects publication (HTTP 400) otherwise.
       - name: Run OpenSSF Scorecard
         uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:


### PR DESCRIPTION
The OpenSSF Scorecard job has been failing on `main`. Scorecard itself ran fine (score 7.9); the publish step rejected the upload with HTTP 400 because the job contained a step outside the set Scorecard allows. When `publish_results: true`, the Scorecard webapp re-fetches the workflow and verifies the scorecard job contains only an allowlisted set of steps.

This removes the extra step from the scorecard job so publication succeeds, and adds a comment so it isn't reintroduced. The other security jobs are unaffected.